### PR TITLE
Add missing inspect import

### DIFF
--- a/ow
+++ b/ow
@@ -29,6 +29,7 @@ import subprocess
 import tempfile
 import xml.etree.cElementTree as cET
 import urllib
+import inspect
 
 nextcloudWebdavRoot = 'remote.php/dav'
 


### PR DESCRIPTION
Without inspect import, parsing will fail:

```
Traceback (most recent call last):
  File "/home/tom/ow/./ow", line 408, in <module>
    isCollectionOrExit(folderWithPhotosUrl)
  File "/home/tom/ow/./ow", line 147, in isCollectionOrExit
    prettyOutputFilename = captureXmlResponse(response.text)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tom/ow/./ow", line 112, in captureXmlResponse
    caller = inspect.stack()[1][3]
             ^^^^^^^
NameError: name 'inspect' is not defined
```